### PR TITLE
[hotfix] Fix `globalEntry` key name in `Info.json`

### DIFF
--- a/Info.json.template
+++ b/Info.json.template
@@ -10,7 +10,7 @@
   },
   "entry": {{#useBundler}}"dist/index.js"{{/useBundler}}{{^useBundler}}"src/index.js"{{/useBundler}},
 {{#hasGlobal}}
-  "global": {{#useBundler}}"dist/global.js"{{/useBundler}}{{^useBundler}}"src/global.js"{{/useBundler}},
+  "globalEntry": {{#useBundler}}"dist/global.js"{{/useBundler}}{{^useBundler}}"src/global.js"{{/useBundler}},
 {{/hasGlobal}}
   "permissions": [
     "show-osd",


### PR DESCRIPTION
As defined in [the plugin dev guide](https://docs.iina.io/pages/dev-guide.html) and [Swift code](https://github.com/iina/iina/blob/d52540c6881ec04a4ce6a4dcee603892e4f8f47c/iina/JavascriptPlugin.swift#L355), `globalEntry` can be defined in `Info.json` for global plugin entry point. The `global` key generated by the plugin template seems to be a typo and has no effect.
