### PR TITLE
Add all permissions to template

### DIFF
--- a/Info.json.template
+++ b/Info.json.template
@@ -14,8 +14,10 @@
 {{/hasGlobal}}
   "permissions": [
     "show-osd",
-    "file-system",
-    "network-request"
+    "show-alert",
+    "video-overlay",
+    "network-request",
+    "file-system"
   ],
   {{#hasSidebar}}"sidebarTab": {
     "name": "Tab"


### PR DESCRIPTION
Ideally you would probably want to templatize  the permissions section. I think the cleanest way to do that and handle commas correctly would be to modify iina-plugin.

For now I think adding all permissions is better than the current template because it means that after the user runs `iina-plugin new` they can immediately use the generated code without needing to edit it. That's how I assumed it would work so I was confused when I had to debug the missing video-overlay permission. The permissions I've added are less serious than file-system so I don't think this has security implications.

I added all permissions listed on https://docs.iina.io/pages/dev-guide.html#plugin-permissions