### PR TITLE
Fix overlay: wait for window-loaded

### DIFF
--- a/src/index.js.template
+++ b/src/index.js.template
@@ -26,18 +26,20 @@ menu.addItem(
 {{/hasWindow}}
 //
 {{#hasOverlay}}
-overlay.loadFile({{#useBundler}}"dist/ui/overlay/index.html"{{/useBundler}}{{^useBundler}}"ui/overlay/index.html"{{/useBundler}});
+event.on("iina.window-loaded", () => {
+  overlay.loadFile({{#useBundler}}"dist/ui/overlay/index.html"{{/useBundler}}{{^useBundler}}"ui/overlay/index.html"{{/useBundler}});
 //
-menu.addItem(
-  menu.item("Show Video Overlay", () => {
-    overlay.show()
-  }),
-);
-menu.addItem(
-  menu.item("Hide Video Overlay", () => {
-    overlay.hide()
-  }),
-);
+  menu.addItem(
+    menu.item("Show Video Overlay", () => {
+      overlay.show()
+    }),
+  );
+  menu.addItem(
+    menu.item("Hide Video Overlay", () => {
+      overlay.hide()
+    }),
+  );
+});
 {{/hasOverlay}}
 //
 {{#hasSidebar}}


### PR DESCRIPTION
The overlay methods used require the window loaded (https://github.com/iina/iina/blob/a8b1fc81879857a3a1be1e053ecc02d917e2692f/iina/JavascriptAPIOverlay.swift#L64).

Fixes:

```
1:56:18.292 pm [player0 - Watchlet][e] Error: overlay.loadFile called when window is not available. Please call it after receiving the "iina.window-loaded" event.
---Stack Trace---
@[native code]
@file:///Users/daniel/projects/watchlet/dist/index.js:11:39
global code@file:///Users/daniel/projects/watchlet/dist/index.js:22:3
-----------------
```